### PR TITLE
Upload image for wordpress const false

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,12 @@ const mainFunction = async (post, summary, options) => {
     const imagePath = image
       ? await getImage(post["Image search query"], post["Title"])
       : null;
-    const imageId = imagePath
-      ? await uploadImage(imagePath, post["Title"])
-      : null;
 
     if (wordpress) {
+      const imageId = imagePath
+        ? await uploadImage(imagePath, post["Title"])
+        : null;
+      
       const categories = post["Categories"];
       const tags = post["Tags"];
       const createdPost = await createPost(


### PR DESCRIPTION
If wordpress const is false, then script shouldn't try upload the image to wordpress. Otherwise, if someone didn't change WP_ENDPOINT key then will get error.